### PR TITLE
Add tests, safer rewrite

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,27 @@
+name: Run C++ Tests
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request: # No branch filter means this runs for all PRs
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # Fetch all history for all tags and branches
+          fetch-depth: 0
+
+      - name: Configure CMake
+        run: cmake -B build -S . -D YOGACPP_BUILD_TESTS=ON
+
+      - name: Build project
+        run: cmake --build build
+
+      - name: Run tests
+        working-directory: ./build
+        run: ctest --output-on-failure

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,8 +2,8 @@ name: Run C++ Tests
 
 on:
   push:
-    branches: [ "main" ]
-  pull_request: # No branch filter means this runs for all PRs
+    branches: [ "master" ]
+  pull_request:
 
 jobs:
   build-and-test:
@@ -12,12 +12,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          # Fetch all history for all tags and branches
-          fetch-depth: 0
 
       - name: Configure CMake
-        run: cmake -B build -S . -D YOGACPP_BUILD_TESTS=ON
+        run: cmake -B build -S . -DYOGACPP_BUILD_TESTS=ON
 
       - name: Build project
         run: cmake --build build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,9 +11,9 @@ FetchContent_Declare(yoga
     GIT_REPOSITORY https://github.com/facebook/yoga.git
     GIT_TAG ${YOGA_VERSION}
 )
-set(YOGA_BUILD_TESTS OFF CACHE BOOL "" FORCE)
-set(YOGA_BUILD_BENCHMARKS OFF CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(yoga)
+
+set_target_properties(yogatests PROPERTIES EXCLUDE_FROM_ALL ON)
 
 add_library(yoga_cpp STATIC
         ${CMAKE_CURRENT_SOURCE_DIR}/include/yoga-cpp/yoga.hpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,8 @@ FetchContent_Declare(yoga
     GIT_REPOSITORY https://github.com/facebook/yoga.git
     GIT_TAG ${YOGA_VERSION}
 )
-
+set(YOGA_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+set(YOGA_BUILD_BENCHMARKS OFF CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(yoga)
 
 add_library(yoga_cpp STATIC
@@ -34,6 +35,8 @@ if (YOGACPP_BUILD_EXAMPLES)
 endif()
 
 if (YOGACPP_BUILD_TESTS)
+    enable_testing()
+
     include(FetchContent)
     FetchContent_Declare(
             googletest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,11 +40,17 @@ if (YOGACPP_BUILD_TESTS)
             GIT_REPOSITORY https://github.com/google/googletest.git
             GIT_TAG v1.17.0
     )
-    # For Windows: Prevent overriding the parent project's compiler/linker settings
     set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
     FetchContent_MakeAvailable(googletest)
 
     add_executable(yoga_cpp_tests test/layout.cpp)
+
+    if(NOT MSVC)
+        target_compile_options(gtest PRIVATE "-frtti")
+        target_compile_options(gtest_main PRIVATE "-frtti")
+        target_compile_options(yoga_cpp_tests PRIVATE "-frtti")
+    endif()
+
     target_link_libraries(yoga_cpp_tests GTest::gtest_main yoga_cpp yogacore)
 
     include(GoogleTest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ target_link_libraries(yoga_cpp PUBLIC yogacore)
 target_include_directories(yoga_cpp PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 option(YOGACPP_BUILD_EXAMPLES "Build example program(s)" OFF)
+option(YOGACPP_BUILD_TESTS "Build tests" OFF)
 
 if (YOGACPP_BUILD_EXAMPLES)
     add_executable(print_dimensions ${CMAKE_CURRENT_SOURCE_DIR}/examples/print_dimensions.cpp)
@@ -30,4 +31,22 @@ if (YOGACPP_BUILD_EXAMPLES)
 
     add_executable(child_iteration ${CMAKE_CURRENT_SOURCE_DIR}/examples/child_iteration.cpp)
     target_link_libraries(child_iteration PRIVATE yoga_cpp)
+endif()
+
+if (YOGACPP_BUILD_TESTS)
+    include(FetchContent)
+    FetchContent_Declare(
+            googletest
+            GIT_REPOSITORY https://github.com/google/googletest.git
+            GIT_TAG v1.17.0
+    )
+    # For Windows: Prevent overriding the parent project's compiler/linker settings
+    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+    FetchContent_MakeAvailable(googletest)
+
+    add_executable(yoga_cpp_tests test/layout.cpp)
+    target_link_libraries(yoga_cpp_tests GTest::gtest_main yoga_cpp yogacore)
+
+    include(GoogleTest)
+    gtest_discover_tests(yoga_cpp_tests)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.15)
 set(YOGA_VERSION v3.2.1)
-set(YOGACPP_VERSION 1.0.0)
+set(YOGACPP_VERSION 2.0.0)
 project(yoga_cpp VERSION ${YOGACPP_VERSION} LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Yoga C++ (yoga-cpp)
-#### version 1.0.0 (Yoga version 3.2.1)
+#### version 2.0.0 (Yoga version 3.2.1)
 
 ## Background
 Yoga is a layout engine by Meta (née Facebook) which is written
@@ -7,9 +7,6 @@ in C++ but exposes only a C API.
 
 This project aims to provide stable user-facing C++ bindings which
 wrap the C API in a safe and modern interface.
-
-It also includes the optional and more opinionated `Yoga::Layout` class,
-which provides a simple way to manage and traverse a Yoga layout tree.
 
 ## Features
 
@@ -33,7 +30,7 @@ include(FetchContent)
 
 FetchContent_Declare(yoga_cpp
     GIT_REPOSITORY https://github.com/detri/yoga-cpp.git
-    GIT_TAG v1.0.0
+    GIT_TAG v2.0.0
 )
 
 FetchContent_MakeAvailable(yoga_cpp)
@@ -42,8 +39,6 @@ target_link_libraries(MyTarget PRIVATE yoga_cpp)
 ```
 
 The project will download and link Yoga for you, so use yoga-cpp as a drop-in replacement and not an add-on.
-
-
 
 ## Barebones Example
 ```c++
@@ -58,12 +53,14 @@ using Layout = Yoga::Layout<Empty>;
 int main()
 {
     Layout layout;
-    auto node = layout.createNode();
-    layout.addToRoot(node);
+    auto root = layout.createNode();
+    root.setWidthPercent(100.f);
+    root.setHeightPercent(100.f);
     
+    auto node = root.createChild();
     node.setWidthPercent(50.f);
     node.setHeightPercent(50.f);
-    layout.calculate(100.f, 100.f);
+    root.calculateLayout(100.f, 100.f);
     auto dimensions = std::format(
         "X: {}, Y: {}, W: {}, H: {}",
         node.getLayoutLeft(),
@@ -77,35 +74,37 @@ int main()
 ```
 
 ## Layout\<Ctx\>
-**Layout\<Ctx\>** is a templated class that manages a layout and its contexts for you.
+The main feature is the `Layout<Ctx>` template class.
+Yoga is just a tree of nodes with no concept of ownership or external storage.
 
-The lifetimes of the nodes in a layout are tied to the layout object's lifetime.
+This class provides context storage for any constructible type and acts as a factory
+that ties Yoga layout nodes and user data together.
 
-It has one requirement, which is that the context must be default-constructible.
-
-The internals consist of:
-
-1. A Yoga::Config which is an owning wrapper around YGConfig.
-2. Flat node storage to keep layout elements alive (you work with copyable references to the tree). This is just `std::vector<OwningNode<Ctx>>`.
-3. A reference (`Node<Ctx>`) to the root node used for calculating the layout.
-
-The API is primarily used via the `createNode()` method, which gives you a non-owning reference to a brand new wrapped Yoga node, with which you can do as you please.
-You can also access the root node with `getRoot()` i.e. to set a background color that may exist in a custom context.
-
+In other words, it acts as the source of truth for Yoga node and context lifetimes.
 ```c++
-struct StyleCtx
-{
-    Color bgColor;
-}
-Layout<StyleCtx> layout;
-layout.getRoot().getContext().bgColor = Color::Black;
+Layout<std::monostate> layout; // Creates a layout with "empty" context
 ```
 
-Nodes and their contexts can be deleted by using `removeNode(Node<Ctx> node)` on a node reference.
-If you track references (i.e. storing Node\<Ctx\> in a map to "name" them), be careful to get rid of any invalid references.
-You can compare nodes with the underlying pointer using the `Node<Ctx>::getRef()` method.
+In the spirit of being a manager class, Layouts are not copyable or moveable.
+If you need to model ownership of a Layout, construct and use it as a smart pointer.
 
-The layout can be calculated based on available viewport space using `calculate(width, height, direction = YGDirectionLTR)`.
+You can create a node and context together like this:
+```c++
+Layout<std::string> layout;
+auto node = layout.createNode("I am a context argument");
+```
+
+Node handles are aware of their owning layouts for ergonomics:
+```c++
+Layout<std::monostate> layout;
+auto node = layout.createNode();
+
+// Adding a child through the handle like this:
+auto child = node.createChild();
+// is equivalent to this:
+auto child = layout.createNode();
+node.insertChild(child, node.getChildCount());
+```
 
 ### Traversing a Layout Tree
 
@@ -117,40 +116,20 @@ for (auto child : node.getChildren()) {
   child.getContext().doStuff();
 }
 ```
-You can also traverse the entire tree starting from the root:
 
-```c++
-std::vector<Node<Ctx>> allNodes;
-layout.walkTree([&](const auto& node) {
-    allNodes.emplace_back(node);
-});
-```
+This allows for straightforward recursion. You can store the resulting references in order and reversely iterate over it if you need to walk the tree in reverse implicit Z-order, such as for hit-testing.
 
 ### Important: Node Lifetime
 
-A `Node<Ctx>` is a non-owning reference to a node that is managed by a `Layout`. The node's memory is freed when the `Layout` object is destroyed or when you explicitly call `layout.removeNode(node)`.
+A `Node<Ctx>` is a non-owning reference to a node that is managed by a `Layout`. The node's memory is freed when the `Layout` object is destroyed or when you explicitly call `layout.destroyNode(node)`.
 
-Be careful to discard any `Node<Ctx>` objects you have stored elsewhere after removing them from the layout, as they will become invalid. You can check for validity by using the `if (node)` pattern.
+Be careful to discard any `Node<Ctx>` objects you have stored elsewhere after removing them from the layout, as they will become invalid. You can check for validity of a specific reference by using `node.valid()`.
+Note that in the case of removal, only the reference used to remove the node will become invalid. The rest will become dangling.
 
 ## Context
 Once you have a node from a layout, its context can be accessed with `getContext()`.
-Note that this returns an optional wrapped reference to your context, i.e. `std::optional<std::reference_wrapper<Ctx>>`.
+The previous version of this library returned an optional wrapped reference. As of v2.0.0, contexts
+are tightly coupled with Nodes within a Layout, so they are no longer optional.
 ```c++
-auto ctxWrapper = node.getContext() // std::optional<std::reference_wrapper<DoStuffCtx>>
-if (ctxWrapper) {
-  auto& ctx = ctxWrapper->get(); // DoStuffCtx& (also available as const)
-  ctx.doStuff();
-}
-```
-
-## Usage without Layout
-`yoga-cpp` can be used as plain Yoga bindings by directly constructing
-OwningNodes yourself and hooking them together. The method names mostly follow
-the C API's naming conventions, in pascalCase and without prefixes,
-except `Layout` methods which property names with styles are prefixed by `getLayout` or `setLayout`
-instead of just `get` or `set`.
-
-```c++
-using MyNode = OwningNode<>; // node type with empty/monostate ctx
-auto node = MyNode{}; // fresh, blank node that will be destroyed when the scope exits
+MyLayoutCtx& ctx = node.getContext(); 
 ```

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The project will download and link Yoga for you, so use yoga-cpp as a drop-in re
 
 ## Barebones Example
 ```c++
-#include <yoga-cpp/yoga.hpp>
+#include <yoga-cpp/yogav1.hpp>
 #include <iostream>
 #include <format>
 

--- a/examples/child_iteration.cpp
+++ b/examples/child_iteration.cpp
@@ -1,31 +1,22 @@
-#include <yoga-cpp/yoga.hpp>
-#include <iostream>
 #include <format>
+#include <iostream>
+#include <yoga-cpp/yoga.hpp>
 
-// define a layout type that stores a name as a context
 using Layout = Yoga::Layout<std::string>;
 
 int main()
 {
     Layout layout;
-    auto node = layout.createNode();
-    layout.addToRoot(node);
+    auto root = layout.createNode("parent");
 
     for (int i = 0; i < 10; i++)
     {
-        auto child = layout.createNode();
-        auto ctx = child.getContext();
-        if (ctx)
-        {
-            auto& ctxRef = ctx->get();
-            ctxRef.append(std::format("child{}", i));
-        }
-        node.insertChild(child);
+        root.createChild(std::format("child{}", i));
     }
 
-    for (auto child : node.getChildren())
+    for (auto child : root.getChildren())
     {
-        std::cout << child.getContext()->get().c_str() << '\n';
+        std::cout << child.getContext().c_str() << '\n';
     }
 
     return 0;

--- a/examples/print_dimensions.cpp
+++ b/examples/print_dimensions.cpp
@@ -1,20 +1,22 @@
-#include <yoga-cpp/yoga.hpp>
-#include <iostream>
 #include <format>
+#include <iostream>
+#include <yoga-cpp/yoga.hpp>
 
-struct Empty {};
-// define a layout type with no context
-using Layout = Yoga::Layout<Empty>;
+using Layout = Yoga::Layout<std::monostate>;
 
 int main()
 {
     Layout layout;
     auto node = layout.createNode();
-    layout.addToRoot(node);
+
+    node.setWidthPercent(100.f);
+    node.setHeightPercent(100.f);
 
     node.setWidthPercent(50.f);
     node.setHeightPercent(50.f);
-    layout.calculate(100.f, 100.f);
+
+    node.calculateLayout(100.f, 100.f);
+
     const auto dimensions = std::format(
         "X: {}, Y: {}, W: {}, H: {}",
         node.getLayoutLeft(),

--- a/test/layout.cpp
+++ b/test/layout.cpp
@@ -1,0 +1,150 @@
+#include <gtest/gtest.h>
+#include <memory>
+#include <vector>
+#include <string>
+
+#include "yoga-cpp/yoga.hpp"
+
+// A simple context struct for testing purposes.
+struct TestContext {
+    int id = 0;
+    std::string name;
+
+    TestContext() = default;
+    TestContext(int id, std::string name) : id(id), name(std::move(name)) {}
+};
+
+
+// Define types for convenience
+using TestLayout = Yoga::Layout<TestContext>;
+using TestNode = Yoga::Node<TestContext>;
+
+// Test Suite for Layout and Node Lifetime Management
+class LayoutLifetimeTest : public ::testing::Test {
+protected:
+    TestLayout layout;
+};
+
+TEST_F(LayoutLifetimeTest, NodeCreationAndDestruction) {
+    ASSERT_NO_THROW({
+        TestNode node = layout.createNode();
+        EXPECT_TRUE(node.valid());
+
+        layout.destroyNode(node);
+        EXPECT_FALSE(node.valid());
+    });
+}
+
+TEST_F(LayoutLifetimeTest, ContextCreationAndAccess) {
+    TestNode node = layout.createNode(42, "MyNode");
+
+    ASSERT_TRUE(node.valid());
+
+    // Check if the context was constructed correctly
+    TestContext& context = node.getContext();
+    EXPECT_EQ(context.id, 42);
+    EXPECT_EQ(context.name, "MyNode");
+
+    // Modify the context and check if it persists
+    context.id = 100;
+    EXPECT_EQ(node.getContext().id, 100);
+}
+
+// Test Suite for Child Management API
+class NodeChildManagementTest : public ::testing::Test {
+protected:
+    TestLayout layout;
+    TestNode parent;
+
+    void SetUp() override {
+        parent = layout.createNode(1, "Parent");
+    }
+};
+
+TEST_F(NodeChildManagementTest, InsertAndRemoveChild) {
+    TestNode child = layout.createNode(2, "Child");
+
+    EXPECT_EQ(parent.getChildCount(), 0);
+
+    parent.insertChild(child, 0);
+    EXPECT_EQ(parent.getChildCount(), 1);
+    EXPECT_EQ(parent.getChild(0), child);
+
+    parent.removeChild(child);
+    EXPECT_EQ(parent.getChildCount(), 0);
+
+    // The child node should still be valid, just detached
+    EXPECT_TRUE(child.valid());
+}
+
+TEST_F(NodeChildManagementTest, CreateChildConvenience) {
+    EXPECT_EQ(parent.getChildCount(), 0);
+
+    TestNode newChild = parent.createChild(10, "CreatedChild");
+
+    EXPECT_EQ(parent.getChildCount(), 1);
+    EXPECT_TRUE(newChild.valid());
+    EXPECT_EQ(newChild.getContext().id, 10);
+    EXPECT_EQ(newChild.getContext().name, "CreatedChild");
+    EXPECT_EQ(parent.getChild(0), newChild);
+}
+
+TEST_F(NodeChildManagementTest, ChildIteration) {
+    std::vector<TestNode> children;
+    children.push_back(parent.createChild(10, "Child1"));
+    children.push_back(parent.createChild(20, "Child2"));
+    children.push_back(parent.createChild(30, "Child3"));
+
+    EXPECT_EQ(parent.getChildCount(), 3);
+
+    int iteratedCount = 0;
+    size_t childIndex = 0;
+    for (const auto& iteratedChild : parent.getChildren()) {
+        EXPECT_TRUE(iteratedChild.valid());
+        EXPECT_EQ(iteratedChild, children[childIndex]);
+        iteratedCount++;
+        childIndex++;
+    }
+
+    EXPECT_EQ(iteratedCount, 3);
+}
+
+TEST_F(NodeChildManagementTest, GetParent) {
+    TestNode child = parent.createChild();
+
+    ASSERT_TRUE(child.getParent().valid());
+    EXPECT_EQ(child.getParent(), parent);
+}
+
+class LayoutCalculationTest : public ::testing::Test {
+protected:
+    TestLayout layout;
+};
+
+TEST_F(LayoutCalculationTest, SimpleFlexLayout) {
+    TestNode root = layout.createNode();
+    root.setFlexDirection(YGFlexDirectionRow);
+    root.setWidth(500.f);
+    root.setHeight(100.f);
+
+    TestNode child1 = layout.createNode();
+    child1.setFlexGrow(1.f);
+
+    TestNode child2 = layout.createNode();
+    child2.setFlexGrow(1.f);
+
+    root.insertChild(child1, 0);
+    root.insertChild(child2, 1);
+
+    root.calculateLayout(500.f, 100.f);
+
+    EXPECT_FLOAT_EQ(child1.getLayoutLeft(), 0);
+    EXPECT_FLOAT_EQ(child1.getLayoutTop(), 0);
+    EXPECT_FLOAT_EQ(child1.getLayoutWidth(), 250.f);
+    EXPECT_FLOAT_EQ(child1.getLayoutHeight(), 100.f);
+
+    EXPECT_FLOAT_EQ(child2.getLayoutLeft(), 250.f);
+    EXPECT_FLOAT_EQ(child2.getLayoutTop(), 0);
+    EXPECT_FLOAT_EQ(child2.getLayoutWidth(), 250.f);
+    EXPECT_FLOAT_EQ(child2.getLayoutHeight(), 100.f);
+}

--- a/test/layout.cpp
+++ b/test/layout.cpp
@@ -5,7 +5,6 @@
 
 #include "yoga-cpp/yoga.hpp"
 
-// A simple context struct for testing purposes.
 struct TestContext {
     int id = 0;
     std::string name;
@@ -15,12 +14,10 @@ struct TestContext {
 };
 
 
-// Define types for convenience
 using TestLayout = Yoga::Layout<TestContext>;
 using TestNode = Yoga::Node<TestContext>;
 
-// Test Suite for Layout and Node Lifetime Management
-class LayoutLifetimeTest : public ::testing::Test {
+class LayoutLifetimeTest : public testing::Test {
 protected:
     TestLayout layout;
 };
@@ -40,17 +37,14 @@ TEST_F(LayoutLifetimeTest, ContextCreationAndAccess) {
 
     ASSERT_TRUE(node.valid());
 
-    // Check if the context was constructed correctly
     TestContext& context = node.getContext();
     EXPECT_EQ(context.id, 42);
     EXPECT_EQ(context.name, "MyNode");
 
-    // Modify the context and check if it persists
     context.id = 100;
     EXPECT_EQ(node.getContext().id, 100);
 }
 
-// Test Suite for Child Management API
 class NodeChildManagementTest : public ::testing::Test {
 protected:
     TestLayout layout;
@@ -73,7 +67,6 @@ TEST_F(NodeChildManagementTest, InsertAndRemoveChild) {
     parent.removeChild(child);
     EXPECT_EQ(parent.getChildCount(), 0);
 
-    // The child node should still be valid, just detached
     EXPECT_TRUE(child.valid());
 }
 


### PR DESCRIPTION
- Swap to a safer pattern for Node ownership, where the Layout will act as the sole factory and owner of Nodes/Contexts and clean them up for you.

- Note about design choices regarding lifetimes: The Layout must outlive Nodes unless `destroyNode` has been called, in which case all instances of Node with the same internal reference become invalid, and using them becomes undefined behavior.  You can still easily use invalid references without care if your UI changes the tree structure at runtime! For example, ChildRanges are intended to be ephemeral, and you should not add or remove children while iterating. Hanging on to references to nodes you may delete later is a bad idea and an easy way to encounter an assertion, or worse, a crash. Have a plan to clean them up if you remove them - Yoga is intended to be used as a C-like API, so some diligence is still required (but not as much). View "Node<Ctx>" instances as dumb pointers that act like references and "Layout" as the source of truth for node and context lifetimes that will clean up created nodes and their contexts for you.

- This PR also adds a GTest suite, which consist mostly of sanity checks, since this library doesn't add much besides safer context access and more convenient cleanup.

- Update docs to reflect API changes